### PR TITLE
removing unnecessary updateSettingValue call

### DIFF
--- a/src/model/controller.tsx
+++ b/src/model/controller.tsx
@@ -105,6 +105,14 @@ const goIn = (s: typeof store) => {
     case "multiple":
       // case "discrete":
       if (isSel) {
+        if (!setting.tags?.includes("ordinal") && curr !== selChoice)
+          s.dispatch(
+            updateSettingValue({
+              cred: { token, endpoint: url },
+              path,
+              value: selChoice,
+            })
+          );
         s.dispatch(hhdSlice.actions.unselect());
       } else {
         s.dispatch(hhdSlice.actions.select());

--- a/src/model/controller.tsx
+++ b/src/model/controller.tsx
@@ -63,15 +63,13 @@ const goIn = (s: typeof store) => {
     return;
   }
 
-  const val = selectSettingState(path)(state) as any;
-
   switch (setting.type) {
     case "bool":
       s.dispatch(
         updateSettingValue({
           cred: { token, endpoint: url },
           path,
-          value: !val,
+          value: !curr,
         })
       );
       break;
@@ -107,14 +105,6 @@ const goIn = (s: typeof store) => {
     case "multiple":
       // case "discrete":
       if (isSel) {
-        if (curr !== selChoice)
-          s.dispatch(
-            updateSettingValue({
-              cred: { token, endpoint: url },
-              path,
-              value: selChoice,
-            })
-          );
         s.dispatch(hhdSlice.actions.unselect());
       } else {
         s.dispatch(hhdSlice.actions.select());


### PR DESCRIPTION
Since navigating left / right in slider is already calling server, there is no need to do it on confirmation. Was only causing issue where `selChoice` populated when entered the field was replacing already update value #11.