### PR TITLE
rpm spec: add fuse dependency

### DIFF
--- a/pkg/hhd-ui.spec
+++ b/pkg/hhd-ui.spec
@@ -14,6 +14,9 @@ BuildRequires:  git
 BuildRequires:  desktop-file-utils
 BuildRequires:  systemd-rpm-macros
 
+Requires:       fuse
+Requires:       fuse-devel
+
 %description
 Configurator interface for Handheld Daemon.
 


### PR DESCRIPTION
Perhaps expected to be already present on a "regular" distro. Alas missing on a minimal install.